### PR TITLE
Redefine $stdout because azure libraries use print for info logging

### DIFF
--- a/bin/azure_cpi
+++ b/bin/azure_cpi
@@ -14,6 +14,9 @@ Bosh::Clouds::Config.configure(cloud_config)
 cloud_properties = cpi_config['cloud']['properties']
 cloud_properties['cpi_log'] = StringIO.new
 
+# Redefine $stdout because azure libraries use print for info logging
+$stdout = STDERR
+
 cpi = Bosh::Clouds::Azure.new(cloud_properties)
 cli = Bosh::Cpi::Cli.new(cpi, cloud_properties['cpi_log'], STDOUT)
 


### PR DESCRIPTION
allows gem to work as an external CPI
